### PR TITLE
Use FFI under GHCJS instead of text-icu

### DIFF
--- a/Text/StringPrep.hs
+++ b/Text/StringPrep.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Text.StringPrep (
 StringPrepProfile(..),
 Range,
@@ -12,10 +13,25 @@ c11,c12,c21,c22,c3,c4,c5,c6,c7,c8,c9
 
 import Data.Text (Text)
 import qualified Data.Text as Text
+#ifndef __GHCJS
 import Data.Text.ICU.Normalize (NormalizationMode(NFKC),normalize)
+#endif
 import qualified Data.Set as Set
 import qualified Data.Map as Map
 import Text.CharRanges
+#ifdef __GHCJS
+import GHCJS.Types (JSString)
+import Data.JSString.Text (textToJSString, textFromJSString)
+
+foreign import javascript unsafe
+    "$r=$1.normalize('NFKC')"
+    js_normalize :: JSString -> JSString
+
+data NormalizationMode = NFKC
+
+normalize :: NormalizationMode -> Text -> Text
+normalize _ = textFromJSString . js_normalize . textToJSString
+#endif
 
 data StringPrepProfile = Profile
 	{

--- a/stringprep.cabal
+++ b/stringprep.cabal
@@ -43,6 +43,7 @@ test-suite tests
               , tasty
               , tasty-quickcheck
               , tasty-th
+              , tasty-hunit
  if impl(ghcjs)
     Build-Depends: ghcjs-base
  else

--- a/stringprep.cabal
+++ b/stringprep.cabal
@@ -6,7 +6,7 @@ License: BSD3
 Author: George Pollard <porges@porg.es>
 Maintainer: George Pollard <porges@porg.es>
 Build-Type: Simple
-Cabal-Version: >=1.8
+Cabal-Version: >=1.10
 License-file: LICENSE
 Category: data
 extra-source-files: Text/*.hs
@@ -21,25 +21,35 @@ source-repository this
     tag: v1.0.0
 
 Library
- Build-Depends: base          >=3 &&    < 5
+ Build-Depends: base          >=3 && < 5
               , containers    >=0.2
-              , text-icu      >=0.6
               , text          >=0.9
+ if impl(ghcjs)
+    Build-Depends: ghcjs-base
+ else
+    Build-Depends: text-icu   >=0.6
  Exposed-modules: Text.StringPrep
                 , Text.StringPrep.Profiles
                 , Text.CharRanges
  ghc-options: -O2 -Wall -fno-warn-name-shadowing
+ default-language: Haskell2010
+ ghcjs-options: -D__GHCJS
 
 test-suite tests
  Build-Depends: base
               , QuickCheck
               , containers
               , text
-              , text-icu
               , tasty
               , tasty-quickcheck
               , tasty-th
+ if impl(ghcjs)
+    Build-Depends: ghcjs-base
+ else
+    Build-Depends: text-icu
  type:         exitcode-stdio-1.0
  main-is:     Tests.hs
  Other-modules: Ranges
  hs-source-dirs: tests .
+ default-language: Haskell2010
+ ghcjs-options: -D__GHCJS

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -4,13 +4,16 @@ module Main where
 
 import           Control.Applicative
 import qualified Data.Set as Set
+import qualified Data.Text as T
 import qualified Ranges as R
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Tasty.TH
+import           Test.Tasty.HUnit
 import qualified Text.CharRanges as CR
 import qualified Text.StringPrep as SP
+import qualified Text.StringPrep.Profiles as SPP
 import           Unsafe.Coerce (unsafeCoerce)
 
 instance Arbitrary SP.Range where
@@ -67,5 +70,12 @@ badRange :: [SP.Range]
 badRange = [CR.Single 'v', CR.Single '\234', CR.Range 'g' '\238']
 
 prop_badRangeToSetEqual = rangeSetsEqual badRange
+
+-- Exercise runStringPrep in the trivial case to make sure that the JavaScript
+-- FFI definition is correct.
+case_runStringPrep :: Assertion
+case_runStringPrep = assertEqual "" result expected
+  where expected = Just (T.pack "text")
+        result = SP.runStringPrep (SPP.namePrepProfile False) (T.pack "text")
 
 main = $(defaultMainGenerator)


### PR DESCRIPTION
The text-icu library is a wrapper around the ICU libraries, which means that it
cannot be used by code compiled with GHCJS. Here we address this by using the
JavaScript FFI to do string normalization in this case.

Tests pass using a version of tasty patched to work with GHCJS (see feuerbach/tasty#150) using the following stack.yaml:
```yaml
resolver: lts-7.19
compiler: ghcjs-0.2.1.9007019_ghc-8.0.1
compiler-check: match-exact

setup-info:
  ghcjs:
    source:
      ghcjs-0.2.1.9007019_ghc-8.0.1:
        url: http://ghcjs.tolysz.org/ghc-8.0-2017-02-05-lts-7.19-9007019.tar.gz
        sha1: d2cfc25f9cda32a25a87d9af68891b2186ee52f9
packages:
- '.'
- '../tasty-0.11.2.1'
```

Also tested with native GHC on macOS Sierra using the following stack.yaml:
```yaml
resolver: lts-8.14
packages:
- '.'
extra-include-dirs:
- /usr/local/opt/icu4c/include
extra-lib-dirs:
- /usr/local/opt/icu4c/lib
```